### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "DanSnow",
   "license": "MIT",
   "peerDependencies": {
-    "babel-runtime": "^5.8.0",
+    "babel-runtime": "^6.0.0",
     "vue": "^1.0.14"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello Dan!
Hope you are ok!
I am contacting you because I have encountered some issues when I updated my npm (and I wanted to run gulp) which using vue.js and vue-recaptcha:

sudo npm update
npm WARN install Couldn't install optional dependency: Unsupported
/home/vagrant/Code/rd.dev
├── UNMET PEER DEPENDENCY babel-runtime@^5.8.0
└── vue-recaptcha@0.0.1  (git+https://github.com/DanSnow/vue-recaptcha.git#7c01c3596339eccb19144721b92b72e32e017747)

npm WARN EPEERINVALID vue-recaptcha@0.0.1 requires a peer of babel-runtime@^5.8.0 but none was installed.

I have digged in, and found few topics:
https://github.com/vuejs/vue-loader/issues/96#issuecomment-162910917
https://phabricator.babeljs.io/T7252
babel/babel#3438

Finally I found Babel upgrade which introduced babel-runtime@6 instead of 5.8.0.
(https://github.com/babel/babel/pull/3438)

I have changed the package.json and changed ^5.8.0 to 6.0.0 for babel-runtime to remove the deprecated dependency, because my other packages required babel6.

Now everything work fine.

I hope you will find it useful
 
Have a great day,
Mariusz