### PR TITLE
Fix warning message: Invalid default value for prop "options"

### DIFF
--- a/src/recaptcha.vue
+++ b/src/recaptcha.vue
@@ -15,7 +15,9 @@
       },
       options: {
         type: Object,
-        default: {}
+        default() {
+          return {};
+        }
       }
     },
     created() {


### PR DESCRIPTION
Vue.js complains that properties default values should be a factory function instead of an object:

`[Vue warn]: Invalid default value for prop "options": Props with type Object/Array must use a factory function to return the default value. (found in component: <vue-recaptcha>)`