### PR TITLE
added error message on render if window.grecaptcha failed to load

### DIFF
--- a/src/recaptcha-wrapper.js
+++ b/src/recaptcha-wrapper.js
@@ -15,7 +15,7 @@ export function createRecaptcha () {
     render (ele, options, cb) {
       this.wait().then(() => {
         if (!window.grecaptcha) {
-	         alert('ReCAPTCHA has not been loaded. Please refresh the page to reload it.');
+          throw new Error('ReCAPTCHA has not been loaded')
 	      }
         cb(window.grecaptcha.render(ele, options))
       })

--- a/src/recaptcha-wrapper.js
+++ b/src/recaptcha-wrapper.js
@@ -14,6 +14,9 @@ export function createRecaptcha () {
 
     render (ele, options, cb) {
       this.wait().then(() => {
+        if (!window.grecaptcha) {
+	         alert('ReCAPTCHA has not been loaded. Please refresh the page to reload it.');
+	      }
         cb(window.grecaptcha.render(ele, options))
       })
     },


### PR DESCRIPTION
I was having a problem if the grecaptcha failed to load. See image below.

![image](https://user-images.githubusercontent.com/17480918/46336821-752e6380-c65e-11e8-803b-baaa36ef97a1.png)

It's kind of hard to replicate and it only happens to me sometimes. It's because the window.grecaptcha failed to load directly from google. I've added an error message in the render function since it's the one that causing the error.

