### PR TITLE
Use prepare instead of postinstall for husky install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:unit": "jest src",
     "test:e2e": "jest e2e",
     "test:types": "tsc -p types/tests",
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   },


### PR DESCRIPTION
Even on husky version 7.0.1, husky install was breaking - tested fix of moving from `postinstall` to `prepare` and that fixed the error.
See https://github.com/typicode/husky/issues/851#issuecomment-804980660
