### PR TITLE
fix: check if this.$slots.default is a function before calling it

### DIFF
--- a/src/Recaptcha.js
+++ b/src/Recaptcha.js
@@ -99,6 +99,13 @@ export default defineComponent({
     }
   },
   render() {
-    return h('div', { ref: 'root' }, this.$slots.default?.())
+    const defaultSlot = this.$slots.default
+    let defaultContent
+    if (typeof defaultSlot === 'function') {
+      defaultContent = defaultSlot()
+    } else {
+      defaultContent = defaultSlot
+    }
+    return h('div', { ref: 'root' }, defaultContent)
   },
 })


### PR DESCRIPTION
This is a bit verbose but it should allow compatibility in vue2 and vue3 of the render function.
Tested locally on vue2, unfortunately I don't think I can test the change works automatically as it
would have to be a test using vue2. Test done on a local project.

fix #740