### PR TITLE
Fix type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+import Vue from "vue"
+
 interface Props {
   sitekey: string
   theme?: string
@@ -11,7 +13,7 @@ interface Props {
   language?: string
 }
 
-declare class VueRecaptcha {
+declare class VueRecaptcha extends Vue {
   $props: Props
   execute(): void
   reset(): void


### PR DESCRIPTION
`defineComponent` from  `@vue/composition-api` defines the `components` property like this 
```typescript
components?: { [key: string]: Component<any, any, any, any> | AsyncComponent<any, any, any, any> };
```

Therefore trying to use VueRecaptcha results in a Typescript error because `VueRecaptcha` is declared as a class that does not implement `Component` or `AsyncComponent`

```typescript
export default defineComponent({
  components: {
    VueRecaptcha, // Typescript error
  },
  // ...
})
```

Thanks
