### PR TITLE
Add support for Vue 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue": "3.2.37"
   },
   "dependencies": {
-    "vue-demi": "^0.13.0"
+    "vue-demi": "^0.13.1"
   },
   "peerDependenciesMeta": {
     "@vue/composition-api": {


### PR DESCRIPTION
To be able to use this component with Vue 2.7, `vue-demi` must have at least version `0.13.1`