### PR TITLE
update vue-demi to fix Vue 2.7 warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue": "3.2.39"
   },
   "dependencies": {
-    "vue-demi": "^0.13.0"
+    "vue-demi": "^0.13.11"
   },
   "peerDependenciesMeta": {
     "@vue/composition-api": {


### PR DESCRIPTION
As Composition API is a part of Vue 2.7, updated `vue-demi` is needed to handle this w/o installing unnecessary `@vue/composition-api` lib. This PR clears up all warnings about `onMounted is called when there is no active component instance to be associated with.` etc.