### PR TITLE
fix: upgrade vue-demi to v0.13.11 to fix vue 2.7 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue": "3.2.39"
   },
   "dependencies": {
-    "vue-demi": "^0.13.0"
+    "vue-demi": "^0.13.11"
   },
   "peerDependenciesMeta": {
     "@vue/composition-api": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7337,7 +7337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-demi@npm:0.13.11, vue-demi@npm:^0.13.0":
+"vue-demi@npm:0.13.11, vue-demi@npm:^0.13.11":
   version: 0.13.11
   resolution: "vue-demi@npm:0.13.11"
   peerDependencies:
@@ -7386,7 +7386,7 @@ __metadata:
     serve-handler: 6.1.3
     typescript: 4.8.3
     vue: 3.2.39
-    vue-demi: ^0.13.0
+    vue-demi: ^0.13.11
   peerDependencies:
     "@vue/composition-api": ^1.0.0-beta.1
     vue: ^2.0.0 || ^3.0.0


### PR DESCRIPTION
Resolved #904
Resolved #910
