### PR TITLE
Bugfix: enterprise recaptcha not loading properly

### DIFF
--- a/src/script-manager/common.ts
+++ b/src/script-manager/common.ts
@@ -142,12 +142,16 @@ export function toStringPair(params: RecaptchaParams): string[][] {
 export function checkRecaptchaLoad() {
   if (typeof window === 'undefined') return false;
 
-  const isLoaded = 'grecaptcha' in window && (
+  const isLoaded = () => 'grecaptcha' in window && (
     'execute' in window.grecaptcha || 
     'execute' in (window.grecaptcha?.enterprise ?? {})
   );
 
-  if (isLoaded) recaptchaLoaded.resolve();
+  const interval = setInterval(() => {
+    if (isLoaded())
+      recaptchaLoaded.resolve();
+      clearInterval(interval);
+  },500);
 
-  return isLoaded;
+  return isLoaded();
 }

--- a/src/script-manager/common.ts
+++ b/src/script-manager/common.ts
@@ -148,9 +148,10 @@ export function checkRecaptchaLoad() {
   );
 
   const interval = setInterval(() => {
-    if (isLoaded())
+    if (isLoaded()) {
       recaptchaLoaded.resolve();
       clearInterval(interval);
+    }
   },500);
 
   return isLoaded();


### PR DESCRIPTION
 i attempted to utilize the plugin with `{enterprise: true}`, but encountered an issue where the recaptchaLoaded promise was never resolved. This led to a halt in execution during the verification process, as the widgetId was not assigned, and neither proxy.execute nor proxy.render were resolving.