### PR TITLE
fix(performance): Google reCaptcha redundant loading

### DIFF
--- a/packages/vue-recaptcha/src/script-manager/head.ts
+++ b/packages/vue-recaptcha/src/script-manager/head.ts
@@ -4,10 +4,15 @@ import { defineScriptLoader, toQueryString } from './common'
 export const createHeadRecaptcha = defineScriptLoader((options) => {
   return () => {
     onMounted(() => {
+
+      if (document.getElementById('vue-recaptcha'))
+        return
+
       const script = document.createElement('script')
       script.src = `${options.recaptchaApiURL}?${toQueryString(options.params)}`
       script.async = true
       script.defer = true
+      script.id = 'vue-recaptcha'
       if (options.nonce) script.nonce = options.nonce
 
       document.head.append(script)


### PR DESCRIPTION
Discussed here: #1532 

When using multiple forms on the same page or with client-side routing, Google reCaptcha files were requested multiple times (the same number of forms on the page). Now, Google reCaptcha is requested only once for the entire system, improving performance in several aspects.

Sorry for the delay in making the pull request, the last few months have been crazy.