### PR TITLE
ci: improve Playwright test configuration

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,12 +18,10 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: "pnpm"
       - uses: moonrepo/setup-toolchain@v0
       - name: Install dependencies
         run: pnpm install
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests
         run: moon run vue-recaptcha:test-e2e
       - name: Run unit tests

--- a/packages/vue-recaptcha/playwright.config.ts
+++ b/packages/vue-recaptcha/playwright.config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { defineConfig, devices } from '@playwright/test'
 import { isCI } from 'std-env'
 
@@ -46,7 +47,10 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: process.env.CI ? 'chrome' : undefined,
+      },
     },
   ],
 


### PR DESCRIPTION
- Change the cache setting in the playwright workflow file from `'pnpm'` to `"pnpm"`
- Configure the playwright tests to run on chrome in CI environments

Signed-off-by: DanSnow <dododavid006@gmail.com>
