### PR TITLE
chore: add package homepage metadata

### DIFF
--- a/packages/vue-recaptcha/package.json
+++ b/packages/vue-recaptcha/package.json
@@ -16,6 +16,7 @@
     "vue",
     "vue-component"
   ],
+  "homepage": "https://github.com/DanSnow/vue-recaptcha#readme",
   "bugs": {
     "url": "https://github.com/DanSnow/vue-recaptcha/issues"
   },


### PR DESCRIPTION
## Summary
- Adds a `homepage` field to the published `vue-recaptcha` package metadata.
- Points npm/package consumers to the repository README alongside the existing bugs, repository, and license metadata.

## Validation
- `node -e "const p=require('./packages/vue-recaptcha/package.json'); if (p.homepage !== 'https://github.com/DanSnow/vue-recaptcha#readme') throw new Error('homepage missing'); console.log(p.homepage)"`
- `pnpm install --frozen-lockfile` (succeeded; also ran the package build during postinstall)
- `pnpm format:check`
- `git diff --check`

Note: `pnpm lint` was also attempted and currently fails on pre-existing repository issues unrelated to this metadata change: an existing `unicorn/prefer-add-event-listener` warning in `src/script-manager/common.ts`, removed `moduleResolution=node10` tsconfig handling reported by oxlint/tsgolint, and a missing generated `packages/docs/.nuxt/tsconfig.json`.

Related bounty tracker: charles-openclaw/charles-microbounties#823


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project homepage information to package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->