### PR TITLE
Add GitHub Pages fallback for docs

### DIFF
--- a/packages/docs/moon.yml
+++ b/packages/docs/moon.yml
@@ -60,6 +60,16 @@ tasks:
     inputs:
       - .output/public/_nuxt
     toolchains: system
+  generate-github-pages-fallback:
+    command:
+      - cp
+      - .output/public/200.html
+      - .output/public/404.html
+    deps:
+      - ~:check-200-html
+    outputs:
+      - .output/public/404.html
+    toolchains: system
   generate-with-nojekyll:
     command:
       - touch
@@ -67,6 +77,7 @@ tasks:
     deps:
       - ~:check-200-html
       - ~:check-nuxt-dir
+      - ~:generate-github-pages-fallback
     outputs:
       - .output/public/.nojekyll
     toolchains: system

--- a/packages/docs/moon.yml
+++ b/packages/docs/moon.yml
@@ -67,6 +67,8 @@ tasks:
       - .output/public/404.html
     deps:
       - ~:check-200-html
+    inputs:
+      - .output/public/200.html
     outputs:
       - .output/public/404.html
     toolchains: system


### PR DESCRIPTION
Fixes #2492.

## Summary
- add a docs publish task that copies Nuxt generated `200.html` to `404.html`
- keep the existing `.nojekyll` publish flow and generated `_nuxt` checks
- make direct GitHub Pages deep links such as `/vue-recaptcha/guide` fall back to the generated app shell

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; data = YAML.load_file('packages/docs/moon.yml'); abort('missing fallback') unless data.fetch('tasks').key?('generate-github-pages-fallback'); puts 'moon.yml parsed'"`\n\nNote: I could not run the full docs generate locally because this checkout does not have the JS workspace dependencies installed (`nuxt`/`moon` were not available through the pinned pnpm environment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a fallback page generation step to improve GitHub Pages behavior by producing a site-level 404 fallback from the generated output.
  * Updated the no-Jekyll build task to run this new fallback step as part of the publishing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->