### PR TITLE
docs: polish site key guide copy

### DIFF
--- a/packages/docs/content/1.guide/0.index.md
+++ b/packages/docs/content/1.guide/0.index.md
@@ -55,13 +55,13 @@ app.use(VueRecaptchaPlugin, {
 });
 ```
 
-Please replace `YOUR_V2_SITEKEY_HERE` and `YOUR_V3_SITEKEY_HERE` with your keys. If you don't have one, please go to [here](https://www.google.com/recaptcha/admin) and apply one
+Please replace `YOUR_V2_SITEKEY_HERE` and `YOUR_V3_SITEKEY_HERE` with your keys. If you don't have one, please go to the [reCAPTCHA admin console](https://www.google.com/recaptcha/admin) and apply one
 
-Not both of the sitekey is required, if you only need reCAPTCHA v2, just provide the `v2SiteKey`
+Both site keys are not required. If you only need reCAPTCHA v2, just provide the `v2SiteKey`
 
-In this document, if you see :badge[v2] which means you'll need to pass `v2SiteKey` and :badge[v3] means you'll need `v3SiteKey`
+In this document, :badge[v2] means you'll need to pass `v2SiteKey`, and :badge[v3] means you'll need `v3SiteKey`
 
-:alert[If you did't provide the corresponding site key, you'll get a runtime error]{type="warning"}
+:alert[If you don't provide the corresponding site key, you'll get a runtime error]{type="warning"}
 
 ## Provide reCAPTCHA script
 

--- a/packages/docs/content/1.guide/0.index.md
+++ b/packages/docs/content/1.guide/0.index.md
@@ -55,9 +55,9 @@ app.use(VueRecaptchaPlugin, {
 });
 ```
 
-Please replace `YOUR_V2_SITEKEY_HERE` and `YOUR_V3_SITEKEY_HERE` with your keys. If you don't have one, please go to the [reCAPTCHA admin console](https://www.google.com/recaptcha/admin) and apply one
+Please replace `YOUR_V2_SITEKEY_HERE` and `YOUR_V3_SITEKEY_HERE` with your keys. If you don't have them, please go to the [reCAPTCHA admin console](https://www.google.com/recaptcha/admin) and obtain them
 
-Both site keys are not required. If you only need reCAPTCHA v2, just provide the `v2SiteKey`
+You do not need to provide both site keys. If you only need reCAPTCHA v2, just provide the `v2SiteKey`
 
 In this document, :badge[v2] means you'll need to pass `v2SiteKey`, and :badge[v3] means you'll need `v3SiteKey`
 

--- a/packages/docs/content/1.guide/0.index.md
+++ b/packages/docs/content/1.guide/0.index.md
@@ -55,11 +55,11 @@ app.use(VueRecaptchaPlugin, {
 });
 ```
 
-Please replace `YOUR_V2_SITEKEY_HERE` and `YOUR_V3_SITEKEY_HERE` with your keys. If you don't have them, please go to the [reCAPTCHA admin console](https://www.google.com/recaptcha/admin) and obtain them
+Please replace `YOUR_V2_SITEKEY_HERE` and `YOUR_V3_SITEKEY_HERE` with your keys. If you don't have them, please go to the [reCAPTCHA admin console](https://www.google.com/recaptcha/admin) and obtain them.
 
-You do not need to provide both site keys. If you only need reCAPTCHA v2, just provide the `v2SiteKey`
+You do not need to provide both site keys. If you only need reCAPTCHA v2, just provide the `v2SiteKey`.
 
-In this document, :badge[v2] means you'll need to pass `v2SiteKey`, and :badge[v3] means you'll need `v3SiteKey`
+In this document, :badge[v2] means you'll need to pass `v2SiteKey`, and :badge[v3] means you'll need `v3SiteKey`.
 
 :alert[If you don't provide the corresponding site key, you'll get a runtime error]{type="warning"}
 


### PR DESCRIPTION
## Summary
- clarify the site key setup wording in the guide
- fix a typo in the runtime-error warning

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified VueRecaptchaPlugin post-setup guidance: both site keys are optional and reCAPTCHA v2 can be used with only its v2 site key.
  * Explained how v2/v3 badges map to the required configuration keys and where to obtain reCAPTCHA credentials.
  * Corrected warning text to show the actual runtime error message when a corresponding site key is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->